### PR TITLE
More description formatting and 2 new options

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A GitHub action that parses a GitHub release and posts it to a Discord channel a
 | footer_icon_url | ❌       |                                                                                                       | String url for the webhook footer picture.      |
 | footer_timestamp| ❌       |                                                                                                       | Boolean to enable footer timestamp.             |
 | max_description | ❌       | "1500"                                                                                                | Max length for the description.                 |
-| reduce_headings | ❌       | false                                                                                                 | Converts H3 to bold, h2 to bold & underline     |
+| reduce_headings | ❌       | false                                                                                                 | Converts H3 to bold, h2 to bold & underline.    |
 
 ## Example Usage
 

--- a/README.md
+++ b/README.md
@@ -7,17 +7,18 @@ A GitHub action that parses a GitHub release and posts it to a Discord channel a
 
 ## Configuration
 
-| Variable        | Required | Default                                                                                                        | Description                                |
-|-----------------|----------|----------------------------------------------------------------------------------------------------------------|--------------------------------------------|
-| webhook_url     | ✔        |                                                                                                                | Discord's webhook url. Use GH repo secrets.|
-| color           | ❌       | "2105893"                                                                                                      | Decimal color value for embed.             |
-| username        | ❌       |                                                                                                                | String username for webhook.               |
-| avatar_url      | ❌       |                                                                                                                | String url to webhook avatar picture.      |
-| content         | ❌       |                                                                                                                | String content for webhook.                |
-| footer_title    | ❌       |                                                                                                                | String title for the webhook footer.       |
-| footer_icon_url | ❌       |                                                                                                                | String url for the webhook footer picture. |
-| footer_timestamp| ❌       |                                                                                                                | Boolean to enable footer timestamp.        |
-| max_description | ❌       | "1500"                                                                                                         | Max length for the description.            |
+| Variable        | Required | Default                                                                                               | Description                                     |
+|-----------------|----------|-------------------------------------------------------------------------------------------------------|-------------------------------------------------|
+| webhook_url     | ✔        |                                                                                                       | Discord's webhook url. Use GH repo secrets.     |
+| color           | ❌       | "2105893"                                                                                             | Decimal color value for embed.                  |
+| username        | ❌       |                                                                                                       | String username for webhook.                    |
+| avatar_url      | ❌       |                                                                                                       | String url to webhook avatar picture.           |
+| content         | ❌       |                                                                                                       | String content for webhook.                     |
+| footer_title    | ❌       |                                                                                                       | String title for the webhook footer.            |
+| footer_icon_url | ❌       |                                                                                                       | String url for the webhook footer picture.      |
+| footer_timestamp| ❌       |                                                                                                       | Boolean to enable footer timestamp.             |
+| max_description | ❌       | "1500"                                                                                                | Max length for the description.                 |
+| reduce_headings | ❌       | false                                                                                                 | Converts H3 to bold, h2 to bold & underline     |
 
 ## Example Usage
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A GitHub action that parses a GitHub release and posts it to a Discord channel a
 | footer_title    | ❌       |                                                                                                                | String title for the webhook footer.       |
 | footer_icon_url | ❌       |                                                                                                                | String url for the webhook footer picture. |
 | footer_timestamp| ❌       |                                                                                                                | Boolean to enable footer timestamp.        |
+| max_description | ❌       | "1500"                                                                                                         | Max length for the description.            |
 
 ## Example Usage
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A GitHub action that parses a GitHub release and posts it to a Discord channel a
 | footer_title    | ❌       |                                                                                                       | String title for the webhook footer.            |
 | footer_icon_url | ❌       |                                                                                                       | String url for the webhook footer picture.      |
 | footer_timestamp| ❌       |                                                                                                       | Boolean to enable footer timestamp.             |
-| max_description | ❌       | "1500"                                                                                                | Max length for the description.                 |
+| max_description | ❌       | "4096"                                                                                                | Max length for the description.                 |
 | reduce_headings | ❌       | false                                                                                                 | Converts H3 to bold, h2 to bold & underline.    |
 
 ## Example Usage

--- a/action.yml
+++ b/action.yml
@@ -30,11 +30,11 @@ inputs:
   max_description:
     description: Max length for the description.
     required: false
-    default: '1500'
+    default: '4096'
   reduce_headings:
     description: Converts H3 to bold, h2 to bold & underline.
     required: false
-    default: false
+    default: 'false'
 runs:
   using: 'node16'
   main: 'index.js'

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,14 @@ inputs:
   footer_timestamp:
     description: Timestamp for the footer.
     required: false
+  max_description:
+    description: Max length for the description.
+    required: false
+    default: '1500'
+  reduce_headings:
+    description: Converts H3 to bold, h2 to bold & underline.
+    required: false
+    default: false
 runs:
   using: 'node16'
   main: 'index.js'

--- a/index.js
+++ b/index.js
@@ -19,8 +19,16 @@ const formatDescription = (description) => {
 
     const edit = description
         .replace(/<!--.*?-->/g, '')
-        .replace(/^### (.*?)$/gm, '**__$1__**')
-        .replace(/^## (.*?)$/gm, '**$1**')
+        // .replace(/^### (.*?)$/gm, '**__$1__**')
+        // .replace(/^## (.*?)$/gm, '**$1**')
+        .replace(/### (.*?)\n/g,function (substring) {
+            const newString = substring.slice(4).replace(/(\r\n|\n|\r)/gm, "")
+            return `**__${newString}__**`
+        })
+        .replace(/## (.*?)\n/g,function (substring) {
+            const newString = substring.slice(3).replace(/(\r\n|\n|\r)/gm, "")
+            return `**${newString}**`
+        })
         .replace(
             new RegExp(
                 "https://github.com/(.+)/(.+)/(issues|pull|compare)/(\\S+)",

--- a/index.js
+++ b/index.js
@@ -5,25 +5,24 @@ import fetch from 'node-fetch';
 /**
  * Stylizes a markdown body into an appropriate embed message style.
  *  Remove HTML comments (commonly added by 'Generate release notes' button)
- *  Better URL linking for commong Github links: PRs, Issues, Compare
+ *  Better URL linking for common Github links: PRs, Issues, Compare
  *  Redundant whitespace and newlines removed, keeping at max 2 to provide space between paragraphs
  *  Trim leading/trailing whitespace
  *  If reduce_headings:
  *   H3s converted to bold and underlined
  *   H2s converted to bold
- * @param description
- * @returns {*}
+ * @param {string} description
  */
 const formatDescription = (description) => {
     let edit = description
-        .replace(/<!--.*?-->/g, '')
+        .replace(/<!--.*?-->/gs, '')
         .replace(
             new RegExp(
-                "https://github.com/(.+)/(.+)/(issues|pull|compare)/(\\S+)",
+                "https://github.com/(.+)/(.+)/(issues|pull|commit|compare)/(\\S+)",
                 "g"
             ),
             (match, user, repo, type, id) => {
-                return `[${getUrlPrefix(type) + id}](${match})`;
+                return `[${getTypePrefix(type) + id}](${match})`
             }
         )
         .replace(/\n\s*\n/g, (ws) => {
@@ -34,8 +33,8 @@ const formatDescription = (description) => {
 
     if (core.getBooleanInput('reduce_headings')) {
         edit = edit
-            .replace(/^### (.*?)$/gm, '**__$1__**')
-            .replace(/^## (.*?)$/gm, '**$1**')
+            .replace(/^###\s+(.+)$/gm, '**__$1__**')
+            .replace(/^##\s+(.+)$/gm, '**$1**')
     }
 
     return edit
@@ -43,14 +42,16 @@ const formatDescription = (description) => {
 
 /**
  * Get a prefix to use for Github link display
- * @param {'issues' | 'pull' | 'compare'} type 
+ * @param {'issues' | 'pull' | 'commit' | 'compare'} type 
  */
-function getUrlPrefix (type) {
+function getTypePrefix (type) {
     switch (type) {
         case 'issues':
             return 'Issue #'
         case 'pull':
             return 'PR #'
+        case 'commit':
+            return 'Commit #'
         case 'compare':
             return ''
         default:
@@ -60,44 +61,62 @@ function getUrlPrefix (type) {
 
 /**
  * Gets the max description length if set to a valid number,
- * otherwise the default of 1500
- * @returns {number}
+ * otherwise the default of 4096
  */
 function getMaxDescription () {
     try {
         const max = core.getInput('max_description')
         if (typeof max === 'string' && max.length) {
+            // 4096 is max for Embed Description
             // https://discord.com/developers/docs/resources/channel#embed-object-embed-limits
-            // 4096 is max for Embed Description, minus 500 to allow for elipsis and link
-            return Math.min(parseInt(max, 10), 4096 - 500)
+            return Math.min(parseInt(max, 10), 4096)
         }
     } catch (err) {
         core.warning(`max_description not a valid number: ${err}`)
     }
-    return 1500
+    return 4096
 }
 
 /**
  * Get the context of the action, returns a GitHub Release payload.
- * @returns {Promise<{html_url, body: (*|string), name: string}>}
  */
-async function getContext () {
+function getContext () {
     const payload = github.context.payload;
-    const maxDesc = getMaxDescription()
 
     return {
-        body: payload.release.body.length < maxDesc
-            ? payload.release.body
-            : payload.release.body.substring(0, maxDesc) + ` ([...](${payload.release.html_url}))`,
+        body: payload.release.body,
         name: payload.release.name,
         html_url: payload.release.html_url
     }
 }
 
 /**
+ * 
+ * @param {string} str
+ * @param {number} maxLength
+ * @param {string=} url
+ */
+function limit(str, maxLength, url) {
+    if (str.length <= maxLength)
+        return str
+    let replacement = '…'
+    if (url) {
+        replacement = `([${replacement}](${url}))`
+    }
+    maxLength = maxLength - replacement.length
+    str = str.substring(0, maxLength)
+
+    const lastWhitespace = str.search(/[^\s]*$/)
+    if (lastWhitespace > -1) {
+        str = str.substring(0, lastWhitespace)
+    }
+
+    return str + replacement
+}
+
+/**
  * Handles the action.
  * Get inputs, creates a stylized response webhook, and sends it to the channel.
- * @returns {Promise<void>}
  */
 async function run () {
     const webhookUrl = core.getInput('webhook_url');
@@ -111,21 +130,24 @@ async function run () {
 
     if (!webhookUrl) return core.setFailed('webhook_url not set. Please set it.');
 
-    const {body, html_url, name} = await getContext();
+    const {body, html_url, name} = getContext();
 
     const description = formatDescription(body);
 
     let embedMsg = {
-        title: name,
+        title: limit(name, 256),
         url: html_url,
         color: color,
         description: description,
         footer: {}
     }
 
-    if (footerTitle != '') embedMsg.footer.text = footerTitle;
+    if (footerTitle != '') embedMsg.footer.text = limit(footerTitle, 2048);
     if (footerIconUrl != '') embedMsg.footer.icon_url = footerIconUrl;
     if (footerTimestamp == 'true') embedMsg.timestamp = new Date().toISOString();
+
+    let embedSize = embedMsg.title.length + (embedMsg.footer?.text?.length ?? 0)
+    embedMsg.description = limit(embedMsg.description, Math.min(getMaxDescription(), 6000 - embedSize), embedMsg.url)
 
     let requestBody = {
         embeds: [embedMsg]

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const formatDescription = (description) => {
     core.info(description)
     core.endGroup()
 
-    const edit = description
+    let edit = description
         .replace(/<!--.*?-->/g, '')
         .replace(
             new RegExp(

--- a/index.js
+++ b/index.js
@@ -5,10 +5,11 @@ import fetch from 'node-fetch';
 /**
  * Stylizes a markdown body into an appropriate embed message style.
  *  Remove HTML comments (commonly added by 'Generate release notes' button)
- *  H3s converted to bold and underlined.
- *  H2s converted to bold.
  *  Redundant whitespace and newlines removed, keeping at max 2 to provide space between paragraphs.
  *  Trim leading/trailing whitespace
+ *  If reduce_headings:
+ *   H3s converted to bold and underlined.
+ *   H2s converted to bold.
  * @param description
  * @returns {*}
  */
@@ -19,18 +20,6 @@ const formatDescription = (description) => {
 
     const edit = description
         .replace(/<!--.*?-->/g, '')
-        // .replace(/^### (.*?)$/gm, '**__$1__**')
-        // .replace(/^## (.*?)$/gm, '**$1**')
-        .replace(/### (.*?)\n/g, function (substring) {
-            core.info('H3', substring)
-            const newString = substring.slice(4).replace(/(\r\n|\n|\r)/gm, "")
-            return `**__${newString}__**`
-        })
-        .replace(/## (.*?)\n/g, function (substring) {
-            core.info('H2', substring)
-            const newString = substring.slice(3).replace(/(\r\n|\n|\r)/gm, "")
-            return `**${newString}**`
-        })
         .replace(
             new RegExp(
                 "https://github.com/(.+)/(.+)/(issues|pull|compare)/(\\S+)",
@@ -45,6 +34,12 @@ const formatDescription = (description) => {
             return nlCount >= 2 ? '\n\n' : '\n'
         })
         .trim()
+
+    if (core.getBooleanInput('reduce_headings')) {
+        edit = edit
+            .replace(/^### (.*?)$/gm, '**__$1__**')
+            .replace(/^## (.*?)$/gm, '**$1**')
+    }
 
     core.startGroup('Updated Description')
     core.info(edit)

--- a/index.js
+++ b/index.js
@@ -5,11 +5,12 @@ import fetch from 'node-fetch';
 /**
  * Stylizes a markdown body into an appropriate embed message style.
  *  Remove HTML comments (commonly added by 'Generate release notes' button)
- *  Redundant whitespace and newlines removed, keeping at max 2 to provide space between paragraphs.
+ *  Better URL linking for commong Github links: PRs, Issues, Compare
+ *  Redundant whitespace and newlines removed, keeping at max 2 to provide space between paragraphs
  *  Trim leading/trailing whitespace
  *  If reduce_headings:
- *   H3s converted to bold and underlined.
- *   H2s converted to bold.
+ *   H3s converted to bold and underlined
+ *   H2s converted to bold
  * @param description
  * @returns {*}
  */

--- a/index.js
+++ b/index.js
@@ -13,7 +13,11 @@ import fetch from 'node-fetch';
  * @returns {*}
  */
 const formatDescription = (description) => {
-    return description
+    core.startGroup('Original Description')
+    core.info(description)
+    core.endGroup()
+
+    const edit = description
         .replace(/<!--.*?-->/g, '')
         .replace(/^### (.*?)$/gm, '**__$1__**')
         .replace(/^## (.*?)$/gm, '**$1**')
@@ -31,6 +35,12 @@ const formatDescription = (description) => {
             return nlCount >= 2 ? '\n\n' : '\n'
         })
         .trim()
+
+    core.startGroup('Updated Description')
+    core.info(edit)
+    core.endGroup()
+
+    return edit
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -14,10 +14,6 @@ import fetch from 'node-fetch';
  * @returns {*}
  */
 const formatDescription = (description) => {
-    core.startGroup('Original Description')
-    core.info(description)
-    core.endGroup()
-
     let edit = description
         .replace(/<!--.*?-->/g, '')
         .replace(
@@ -40,10 +36,6 @@ const formatDescription = (description) => {
             .replace(/^### (.*?)$/gm, '**__$1__**')
             .replace(/^## (.*?)$/gm, '**$1**')
     }
-
-    core.startGroup('Updated Description')
-    core.info(edit)
-    core.endGroup()
 
     return edit
 }

--- a/index.js
+++ b/index.js
@@ -21,11 +21,13 @@ const formatDescription = (description) => {
         .replace(/<!--.*?-->/g, '')
         // .replace(/^### (.*?)$/gm, '**__$1__**')
         // .replace(/^## (.*?)$/gm, '**$1**')
-        .replace(/### (.*?)\n/g,function (substring) {
+        .replace(/### (.*?)\n/g, function (substring) {
+            core.info('H3', substring)
             const newString = substring.slice(4).replace(/(\r\n|\n|\r)/gm, "")
             return `**__${newString}__**`
         })
-        .replace(/## (.*?)\n/g,function (substring) {
+        .replace(/## (.*?)\n/g, function (substring) {
+            core.info('H2', substring)
             const newString = substring.slice(3).replace(/(\r\n|\n|\r)/gm, "")
             return `**${newString}**`
         })


### PR DESCRIPTION
Perform additional formatting w/ options on the description:

- remove HTML comments which are often added by the 'Generate release notes' button
- trim the resulting description
- reduce consecutive whitespace/newlines into a minimum of 2 to allow separation in paragraphs
- parse common Github URLs to more appropriate display
- add options:
  - max_description: Discord allows a [max of 4096](https://discord.com/developers/docs/resources/channel#embed-object-embed-limits), so allow for more but prevent from going over with ellipses and link "buffer"
  - reduce_headings: Enabling this will actually perform what looks like was intended of converting H2's to bold and H3's to bold and underline for a more reduced display. I left it defaulted at `false` to mimic it's current state which didn't seem to actually perform the heading conversion. I couldn't find a reason why the original code wasn't performing the heading conversion, but the new regex does work.