### PR TITLE
fix: improve @ mention parsing for GitHub usernames

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,11 +28,14 @@ const reduceNewlines = (text) => text.replace(/\n\s*\n/g, (ws) => {
 });
 
 /**
- * Converts @mentions to GitHub profile links.
+ * Converts @mentions to GitHub profile links for valid GitHub usernames.
  * @param {string} text The input text.
- * @returns {string} The text with @mentions converted to links.
+ * @returns {string} The text with valid @mentions converted to links.
  */
-const convertMentionsToLinks = (text) => text.replace(/@(\S+)/g, (match, name) => `[@${name}](https://github.com/${name})`);
+const convertMentionsToLinks = (text) => text.replace(
+    /(?<![/@\w])@((?!-)(?!.*?--)[a-zA-Z0-9](?:-?[a-zA-Z0-9]){0,37})(?![.\w/-])(?!.*\])/g,
+    (match, name) => `[@${name}](https://github.com/${name})`
+);
 
 /**
  * Reduces headings to a smaller format if 'reduce_headings' is enabled.


### PR DESCRIPTION
This PR improves the @ mention parsing in the `convertMentionsToLinks` function to more accurately identify [valid GitHub usernames](https://docs.github.com/en/enterprise-cloud@latest/admin/managing-iam/iam-configuration-reference/username-considerations-for-external-authentication#about-username-normalization) while avoiding false positives. This addresses the issue raised in #32.

> Usernames for user accounts on GitHub can only contain alphanumeric characters and dashes (-).

## Key Changes
- Updated regex to match GitHub's username requirements
- Prevented matching of package names and email addresses
- Excluded matches within code snippets, URLs, and Markdown links

You can test the new regex pattern here: https://regex101.com/r/vBdvdh/1

This update ensures that only valid GitHub usernames are converted to profile links.

## Current Behavior
The following screenshot shows how package names are incorrectly being converted to GitHub profile links in [v1.15.1](https://github.com/SethCohen/github-releases-to-discord/releases/tag/v1.15.1)

<img width="413" alt="image" src="https://github.com/user-attachments/assets/080f0b8d-e016-4007-94fe-a90ba4c2b951">

## After This Change
With this PR, package names will no longer be converted to links, resolving the issue shown above.