### PR TITLE
Add option to strip PR and commit links

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,4 +21,4 @@ jobs:
           footer_timestamp: ${{ inputs.FOOTER_TIMESTAMP }}
           max_description: ${{ inputs.MAX_DESCRIPTION }}
           reduce_headings: ${{ inputs.REDUCE_HEADINGS }}
-          
+          remove_github_reference_links: ${{ inputs.REMOVE_GITHUB_REFERENCE_LINKS }}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A GitHub Action that sends a stylized Discord webhook containing the description
   - **Whitespace Optimization:** Reduces redundant newlines and excess spaces while preserving proper paragraph spacing.
 - **Mention Conversion:** Converts GitHub mentions (e.g., `@username`) into clickable GitHub profile links for easy navigation.
 - **Markdown Link Conversion:**
+- **Link Removal (Optional):** Remove PR and commit links from the changelog.
   - **PR Links:** Converts pull request URLs into Markdown links (e.g., `[PR #1](https://github.com/OWNER/REPO/pull/1)`).
   - **Issue Links:** Converts issue URLs into Markdown links (e.g., `[Issue #1](https://github.com/OWNER/REPO/issues/1)`).
   - **Changelog Links:** Converts changelog comparison URLs into concise Markdown links (e.g., `[v1.0.0...v1.1.0](https://github.com/OWNER/REPO/compare/v1.0.0...v1.1.0)`).
@@ -42,6 +43,7 @@ A GitHub Action that sends a stylized Discord webhook containing the description
 | footer_icon_url | ❌       |                                                                                                       | String url for the webhook footer picture.      |
 | footer_timestamp| ❌       |                                                                                                       | Boolean to enable footer timestamp.             |
 | max_description | ❌       | "4096"                                                                                                | Max length for the description.                 |
+| remove_pr_commit_links | ❌       | false                                                     | Remove PR and commit links from the description.    |
 | reduce_headings | ❌       | false                                                                                                 | Converts H3 to bold, h2 to bold & underline.    |
 
 ## Example Usage
@@ -71,6 +73,7 @@ jobs:
           footer_icon_url: "https://cdn.discordapp.com/avatars/487431320314576937/bd64361e4ba6313d561d54e78c9e7171.png"
           footer_timestamp: true
           max_description: '4096'
+          remove_pr_commit_links: true
           reduce_headings: true
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ A GitHub Action that sends a stylized Discord webhook containing the description
 | footer_icon_url | ❌       |                                                                                                       | String url for the webhook footer picture.      |
 | footer_timestamp| ❌       |                                                                                                       | Boolean to enable footer timestamp.             |
 | max_description | ❌       | "4096"                                                                                                | Max length for the description.                 |
-| remove_pr_commit_links | ❌       | false                                                     | Remove PR and commit links from the description.    |
+| remove_github_reference_links | ❌       | false                                                     | Remove any PR, commit, and issue links from the description.    |
 | reduce_headings | ❌       | false                                                                                                 | Converts H3 to bold, h2 to bold & underline.    |
 
 ## Example Usage
@@ -73,7 +73,7 @@ jobs:
           footer_icon_url: "https://cdn.discordapp.com/avatars/487431320314576937/bd64361e4ba6313d561d54e78c9e7171.png"
           footer_timestamp: true
           max_description: '4096'
-          remove_pr_commit_links: true
+          remove_github_reference_links: true
           reduce_headings: true
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -31,10 +31,10 @@ inputs:
     description: Max length for the description.
     required: false
     default: '4096'
-  remove_pr_commit_links:
-    description: Remove PR and commit links from the description.
+  remove_github_reference_links:
+    description: Remove any PR, commit, and issue links from the description.
     required: false
-    default: "false"
+    default: 'false'
   reduce_headings:
     description: Converts H3 to bold, h2 to bold & underline.
     required: false

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
     description: Max length for the description.
     required: false
     default: '4096'
+  remove_pr_commit_links:
+    description: Remove PR and commit links from the description.
+    required: false
+    default: "false"
   reduce_headings:
     description: Converts H3 to bold, h2 to bold & underline.
     required: false

--- a/index.js
+++ b/index.js
@@ -38,13 +38,21 @@ const convertMentionsToLinks = (text) => text.replace(
 );
 
 /**
- * Removes PR and commit links from the text.
+ * Removes any GitHub PR, commit, or issue links from the text, including markdown links.
  * @param {string} text The input text.
- * @returns {string} The text without PR and commit links.
+ * @returns {string} The text without GitHub PR and commit links.
  */
-const removePrCommitLinks = (text) => text
-    .replace(/https:\/\/github\.com\/[^\s)]+\/pull\/\d+/g, '')
-    .replace(/https:\/\/github\.com\/[^\s)]+\/commit\/\w+/g, '');
+const removeGithubReferenceLinks = (text) => text
+    // Remove markdown links to PRs, commits, and issues
+    .replace(/\[[^\]]*\]\(https:\/\/github\.com\/[^(\s)]+\/pull\/\d+\)/g, '')
+    .replace(/\[[^\]]*\]\(https:\/\/github\.com\/[^(\s)]+\/commit\/\w+\)/g, '')
+    .replace(/\[[^\]]*\]\(https:\/\/github\.com\/[^(\s)]+\/issues\/\d+\)/g, '')
+    // Remove bare PR, commit, and issue URLs
+    .replace(/https:\/\/github\.com\/[^(\s)]+\/pull\/\d+/g, '')
+    .replace(/https:\/\/github\.com\/[^(\s)]+\/commit\/\w+/g, '')
+    .replace(/https:\/\/github\.com\/[^(\s)]+\/issues\/\d+/g, '')
+    // Remove empty parentheses left behind
+    .replace(/\(\s*\)/g, '');
 
 /**
  * Reduces headings to a smaller format if 'reduce_headings' is enabled.
@@ -91,8 +99,9 @@ const formatDescription = (description) => {
     let edit = removeCarriageReturn(description);
     edit = removeHTMLComments(edit);
     edit = reduceNewlines(edit);
-    if (core.getBooleanInput('remove_pr_commit_links')) {
-        edit = removePrCommitLinks(edit);
+        
+    if (core.getBooleanInput('remove_github_reference_links')) {
+        edit = removeGithubReferenceLinks(edit);
     }
     edit = convertMentionsToLinks(edit);
     edit = convertLinksToMarkdown(edit);

--- a/index.js
+++ b/index.js
@@ -38,6 +38,15 @@ const convertMentionsToLinks = (text) => text.replace(
 );
 
 /**
+ * Removes PR and commit links from the text.
+ * @param {string} text The input text.
+ * @returns {string} The text without PR and commit links.
+ */
+const removePrCommitLinks = (text) => text
+    .replace(/https:\/\/github\.com\/[^\s)]+\/pull\/\d+/g, '')
+    .replace(/https:\/\/github\.com\/[^\s)]+\/commit\/\w+/g, '');
+
+/**
  * Reduces headings to a smaller format if 'reduce_headings' is enabled.
  * Converts H3 to bold+underline, H2 to bold.
  * @param {string} text The input text.
@@ -82,6 +91,9 @@ const formatDescription = (description) => {
     let edit = removeCarriageReturn(description);
     edit = removeHTMLComments(edit);
     edit = reduceNewlines(edit);
+    if (core.getBooleanInput('remove_pr_commit_links')) {
+        edit = removePrCommitLinks(edit);
+    }
     edit = convertMentionsToLinks(edit);
     edit = convertLinksToMarkdown(edit);
     edit = edit.trim();


### PR DESCRIPTION
## Summary
- add `remove_pr_commit_links` input to remove PR/commit links
- document link removal feature
- handle new input in the action

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6850d86650a8832f8b4d97437dca7e9d